### PR TITLE
Fix 'undefined' sticky pageHeader in SaveAs mode

### DIFF
--- a/site/Paradoc.js
+++ b/site/Paradoc.js
@@ -4667,13 +4667,13 @@ if (MODE === "bookmarkNodeMode") {
           var markdownAndHeader = parseYamlHeader(markdownNormalizedYaml, window.location.pathname);
           // Parse out the YAML header if present.
           var data = markdownAndHeader;
-          data.linkText = data.linkText || kebabToWords(pageKey);
           cb(err, data);
         });
       };
       var alreadySpecifiedPageKeys = Object.keys(runner.pageState);
       var handleFetchDone = function (pageKey, err, data) {
         console.log('handling fetch done', pageKey);
+        data.headerProps.linkText = data.headerProps.linkText || kebabToWords(pageKey);
         runner.pageState[pageKey].markdownAndHeader = data;
         if(err) {
           console.error("[Flatdoc] fetching Markdown data failed for page:" + pageKey + ".", err);

--- a/site/Paradoc.js
+++ b/site/Paradoc.js
@@ -4667,6 +4667,7 @@ if (MODE === "bookmarkNodeMode") {
           var markdownAndHeader = parseYamlHeader(markdownNormalizedYaml, window.location.pathname);
           // Parse out the YAML header if present.
           var data = markdownAndHeader;
+          data.linkText = data.linkText || kebabToWords(pageKey);
           cb(err, data);
         });
       };


### PR DESCRIPTION
Currently `linkText` is being handled in multiple places and leads to `undefined` linkText in SaveAs mode.
I decided to fix `linkText` right after `headerProps` parsing would be the best course of action.

Places that currently handles `linkText`:
- [Dev mode template engine](https://github.com/jordwalke/paradoc/blob/739e329c8c801b38895ebe4c036423f5b2f14fe0/site/Paradoc.js#L4475)
- [Injecting linkText to dataset in dev mode without normalizing it](https://github.com/jordwalke/paradoc/blob/739e329c8c801b38895ebe4c036423f5b2f14fe0/site/Paradoc.js#L4819)
- [Render it in SaveAs mode without normalizing it, please note that as this step, `linkText === String("undefined")`](https://github.com/jordwalke/paradoc/blob/739e329c8c801b38895ebe4c036423f5b2f14fe0/site/Paradoc.js#L4766)